### PR TITLE
ARM builds

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,11 +1,16 @@
-FROM ghcr.io/graalvm/graalvm-ce:latest
+FROM ubuntu:22.04
 
-RUN gu install native-image
+RUN apt-get update
+RUN apt-get -y install curl zip unzip git gcc zlib1g-dev
 
-# RUN rm /bin/sh && ln -s /bin/bash /bin/sh
-# RUN yum -qq -y install curl
-# RUN curl -s https://get.sdkman.io | bash
-# RUN chmod a+x "$HOME/.sdkman/bin/sdkman-init.sh"
-# RUN source "$HOME/.sdkman/bin/sdkman-init.sh"
-#
-# RUN sdk install sbt
+RUN curl -s "https://get.sdkman.io" | bash
+ENV SDKMAN_INIT="/root/.sdkman/bin/sdkman-init.sh"
+
+SHELL ["/bin/bash", "-c"]
+
+RUN source "$SDKMAN_INIT" && \
+    sdk install java 22.1.0.r17-grl && \
+    sdk install sbt && \
+    gu install native-image
+
+CMD source "$SDKMAN_INIT" && ./build.sh

--- a/build-in-docker.sh
+++ b/build-in-docker.sh
@@ -1,0 +1,7 @@
+#!/bin/bash
+docker build -t git-mkver .
+docker run \
+    --rm \
+    -v $(pwd):/workspace \
+    -w /workspace \
+    -it git-mkver

--- a/build.sh
+++ b/build.sh
@@ -1,9 +1,8 @@
 #!/bin/bash
 set -e
 
-# Note requires a previous version of git-mkver to have been built and on the path!
-git mkver -c git-mkver.conf patch
-version=`git mkver -c git-mkver.conf next`
+sbt -error -batch "run -c git-mkver.conf patch"
+version=`sbt -error -batch "run -c git-mkver.conf next"`
 
 sbt assembly
 

--- a/build.sh
+++ b/build.sh
@@ -3,6 +3,7 @@ set -e
 
 sbt -error -batch "run -c git-mkver.conf patch"
 version=`sbt -error -batch "run -c git-mkver.conf next"`
+arch=`arch`
 
 sbt assembly
 
@@ -11,27 +12,14 @@ if [[ "$(uname)" == "Darwin" ]]
 then
   pushd target
   native-image -H:IncludeResources='.*conf$' --no-fallback -jar scala-2.12/git-mkver-assembly-$version.jar
-  mv git-mkver-assembly-$version git-mkver-darwin-amd64-$version
-  cp git-mkver-darwin-amd64-$version git-mkver
+  mv git-mkver-assembly-$version git-mkver-darwin-$arch-$version
+  cp git-mkver-darwin-$arch-$version git-mkver
   chmod +x git-mkver
-  tar -cvzf git-mkver-darwin-amd64-$version.tar.gz git-mkver
+  tar -cvzf git-mkver-darwin-$arch-$version.tar.gz git-mkver
   rm git-mkver
   popd
 
-  # Linux
-  docker run -v $(pwd):/workspace -it git-mkver \
-    /bin/bash -c "cd /workspace/target; native-image -H:IncludeResources='.*conf$' --no-fallback -jar scala-2.12/git-mkver-assembly-$version.jar; mv git-mkver-assembly-$version git-mkver-linux-amd64-$version"
-
-  pushd target
-  cp git-mkver-linux-amd64-$version git-mkver
-  chmod +x git-mkver
-  tar -cvzf git-mkver-linux-amd64-$version.tar.gz git-mkver
-  rm git-mkver
-  popd
-
-  DARWIN_SHA256=$(openssl dgst -sha256 target/git-mkver-darwin-amd64-$version.tar.gz | cut -f2 -d' ')
-  LINUX_SHA256=$(openssl dgst -sha256 target/git-mkver-linux-amd64-$version.tar.gz | cut -f2 -d' ')
-
+  DARWIN_SHA256=$(openssl dgst -sha256 target/git-mkver-darwin-$arch-$version.tar.gz | cut -f2 -d' ')
   echo "DARWIN_SHA256=$DARWIN_SHA256"
   #sed -i '' -e "s/MKVER_SHA256  = \".*\".freeze/MKVER_SHA256  = \"$DARWIN_SHA256\".freeze/g" /usr/local/Homebrew/Library/Taps/idc101/homebrew-gitmkver/Casks/git-mkver.rb
 fi
@@ -41,10 +29,13 @@ if [[ "$(uname)" == "Linux" ]]
 then
   pushd target
   native-image -H:IncludeResources='.*conf$' --no-fallback -jar scala-2.12/git-mkver-assembly-$version.jar
-  mv git-mkver-assembly-$version git-mkver-linux-amd64-$version
-  cp git-mkver-linux-amd64-$version git-mkver
+  mv git-mkver-assembly-$version git-mkver-linux-$arch-$version
+  cp git-mkver-linux-$arch-$version git-mkver
   chmod +x git-mkver
-  tar -cvzf git-mkver-linux-amd64-$version.tar.gz git-mkver
+  tar -cvzf git-mkver-linux-$arch-$version.tar.gz git-mkver
   rm git-mkver
   popd
+
+  LINUX_SHA256=$(openssl dgst -sha256 target/git-mkver-linux-$arch-$version.tar.gz | cut -f2 -d' ')
+  echo "LINUX_SHA256=$LINUX_SHA256"
 fi


### PR DESCRIPTION
Hi, I've found `native-image` now supports ARM, so I've done some things:

- Updated `build.sh` to be run either in Linux or macOS independently of the architecture
- Added a `build-in-docker.sh` which runs `build.sh` inside Docker (I've tested it on my M1 MacBook)
- `build.sh` doesn't need a previous `git-mkver` in order to run