### PR TITLE
docs: Fix typo in config example

### DIFF
--- a/docs/config_examples.md
+++ b/docs/config_examples.md
@@ -127,6 +127,6 @@ commitMessageActions: [
   # The rest of the conventional commits
   {
     pattern: "(build|ci|chore|docs|perf|refactor|revert|style|test)(\\(.+\\))?:"
-    action: NoIncremen
+    action: NoIncrement
   }
 ```


### PR DESCRIPTION
The missing `t` is hard to spot but causes an error if used as-is