### PR TITLE
fix: broken next-version regex pattern

### DIFF
--- a/src/main/scala/net/cardnell/mkver/MkVer.scala
+++ b/src/main/scala/net/cardnell/mkver/MkVer.scala
@@ -105,7 +105,7 @@ object MkVer {
   }
 
   def calcBumps(lines: List[String], commitMessageActions: List[CommitMessageAction], bumps: VersionBumps): VersionBumps = {
-    val overrideRegex = "next-version: *(\\d+\\.\\d+\\.\\d+)".r
+    val overrideRegex = "    next-version: *(\\d+\\.\\d+\\.\\d+)".r
     if (lines.isEmpty) {
       bumps
     } else {

--- a/src/test/scala/net/cardnell/mkver/MkVerSpec.scala
+++ b/src/test/scala/net/cardnell/mkver/MkVerSpec.scala
@@ -45,7 +45,8 @@ object MkVerSpec extends DefaultRunnableSpec {
           assert(calcBumps(List("    fix(a component): change"), commitMessageActions, VersionBumps()))(equalTo(VersionBumps(patch = true))) &&
           assert(calcBumps(List("    patch(a component): change"), commitMessageActions, VersionBumps()))(equalTo(VersionBumps(patch = true))) &&
           assert(calcBumps(List("    some random commit"), commitMessageActions, VersionBumps()))(equalTo(VersionBumps())) &&
-          assert(calcBumps(List("    Merged PR: feat: change"), commitMessageActions, VersionBumps()))(equalTo(VersionBumps(minor = true)))
+          assert(calcBumps(List("    Merged PR: feat: change"), commitMessageActions, VersionBumps()))(equalTo(VersionBumps(minor = true))) &&
+          assert(calcBumps(List("    next-version: 9.4.3"), commitMessageActions, VersionBumps()))(equalTo(VersionBumps(commitOverride = Some(Version(9, 4, 3)))))
       },
       test("should parse real log") {
         assert(calcBumps(fullLog.linesIterator.toList, commitMessageActions, VersionBumps()))(equalTo(VersionBumps(patch = true, commitCount = 1)))


### PR DESCRIPTION
Commits with "next-version" were not properly overriding the next version because the regex has an implicit ^ at the beginning of the pattern. Since the line always begins with four spaces, it will thus never match overrideRegex.
Added a test to cover this use case.