### PR TITLE
feat: resolve environment variables in config

### DIFF
--- a/src/main/scala/net/cardnell/mkver/AppConfig.scala
+++ b/src/main/scala/net/cardnell/mkver/AppConfig.scala
@@ -288,7 +288,7 @@ object AppConfig {
 
   def tryLoadAppConfig(file: String): Task[AppConfig] = {
     for {
-      configSource <- TypesafeConfigSource.fromTypesafeConfig(ConfigFactory.parseFile(new java.io.File(file)))
+      configSource <- TypesafeConfigSource.fromTypesafeConfig(ConfigFactory.parseFile(new java.io.File(file)).resolve())
         .fold(l => Task.fail(MkVerException(l.getMessage())), r => Task.succeed(r))
       appConfig <- read(AppConfig.appConfigDesc from configSource)
         .fold(l => Task.fail(MkVerException("Unable to parse config: " + l.prettyPrint())), r => Task.succeed(r))


### PR DESCRIPTION
This can allow users to reuse the same mkver.conf for multiple projects. For example, given a configuration
```
defaults {
  patches: [ ${?PATCHES} ]
}
patches: [
  {
    name: ABC
    filePatterns: [ "abc.json" ]
    replacements: [
      {
        find: "ABC: {VersionRegex}"
        replace: "ABC: {Version}"
      }
    ]
  }
  {
    name: DEF
    filePatterns: [ "def.json" ]
    replacements: [
      {
        find: "DEF: {VersionRegex}"
        replace: "DEF: {Version}"
      }
    ]
  }
]
```
one may choose their patch 
```bash
$ export PATCHES="ABC"
$ git mkver patch
Patching file: 'abc.json', new value: 'ABC: 4.5.6'

# elsewhere...
$ export PATCHES="DEF"
$ git mkver patch
Patching file: 'def.json', new value: 'DEF: 4.5.6'

```
If I'm not mistaken, this makes env.VARIABLE expansion obsolete in favor of letting Typesafe handle the expansion.
However, env.VARIABLE will need to continue be supported for backward compatibility until the next breaking change..